### PR TITLE
Bugfix: Non-first layer fan speed should use FAN_SPEED

### DIFF
--- a/pressure_advance/pressure_advance.js
+++ b/pressure_advance/pressure_advance.js
@@ -354,7 +354,7 @@ ${(FIRMWARE == 'klipper' ? `SET_VELOCITY_LIMIT ACCEL=${ACCELERATION}` : `M204 P$
   for (let i = (ANCHOR_OPTION == 'anchor_layer' ? 1 : 0); i < NUM_LAYERS ; i++){ // skip first layer if using full anchor layer
 
     if (i == 1){ // set new fan speed after first layer
-      pa_script += `M106 S${Math.round(FAN_SPEED_FIRSTLAYER * 2.55)}${(FIRMWARE == 'marlin' ? ` P${TOOL_INDEX}` : '')} ; Set fan speed\n`
+      pa_script += `M106 S${Math.round(FAN_SPEED * 2.55)}${(FIRMWARE == 'marlin' ? ` P${TOOL_INDEX}` : '')} ; Set fan speed\n`
     }
 
     TO_Z = (i * HEIGHT_LAYER) + HEIGHT_FIRSTLAYER;


### PR DESCRIPTION
Just noticed the part fans were not switching on because the second M106 was using FAN_SPEED_FIRSTLAYER instead of FAN_SPEED. I have not tested this change.